### PR TITLE
Don't surround filename with quotes

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -104,7 +104,7 @@ function replaceExt(filePath: string, ext: string) {
 }
 
 export function compile (ctx: CompileContext): Promise<CompileResult> {
-    var args: string[] = getArgs(ctx.options).concat('"' + path.resolve(ctx.file) + '"');
+    var args: string[] = getArgs(ctx.options).concat(path.resolve(ctx.file));
     var tsc: string = getTsc(resolveTypeScriptBinPath());
 
     return executeNode([tsc].concat(args)).then(res => {


### PR DESCRIPTION
Filename is resolving after these actions? Gives wrong behaviour to me:

```
Version: webpack 1.3.1-beta8
        Asset  Size  Chunks             Chunk Names
    bundle.js  1495       1  [emitted]  bundle
   [0] ./src/app.ts 0 {1} [built] [1 error]

ERROR in ./src/app.ts
error TS5012: Cannot read file '"D:\Workspace\super-bundler\src\app.ts"': ENOENT, no such file or directory 'D:\Workspace\super-bundler\"D:\Workspace\super-bundler\src\app.ts"'

```

_src/app.ts_

```
var Greeter = require('app/Greeter.ts'); // Regular Nodejs-style require call
var greeter = new Greeter("World");
greeter.echo(greeter.greeting);
```

_src/Greeter.ts_

```
class Greeter {
    name: string;
    constructor(name) {
        this.name = name;
    }
    get greeting () {
        return 'Hello, ' + this.name + '!';
    }
}
export = Greeter
```

And alias in Webpack config:

```
// ....
        resolve: {
          alias: {
            app: __dirname + "/src/"
          },
          extensions: ["", ".webpack.js", ".web.js", ".js", ".ts"]
        },
// ....
```
